### PR TITLE
Import self promotions from promoted-builds plugin

### DIFF
--- a/src/main/java/org/cloudbees/literate/jenkins/promotions/SelfPromotionBadge.java
+++ b/src/main/java/org/cloudbees/literate/jenkins/promotions/SelfPromotionBadge.java
@@ -1,0 +1,32 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2011-2014, CloudBees, Inc., Vincent Latombe
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.cloudbees.literate.jenkins.promotions;
+
+/**
+ * Indicates that the promotion was automatically done by {@link org.cloudbees.literate.jenkins.promotions.conditions.SelfPromotionCondition}.
+ *
+ * @author Kohsuke Kawaguchi
+ */
+public class SelfPromotionBadge extends PromotionBadge {
+}

--- a/src/main/java/org/cloudbees/literate/jenkins/promotions/conditions/SelfPromotionCondition.java
+++ b/src/main/java/org/cloudbees/literate/jenkins/promotions/conditions/SelfPromotionCondition.java
@@ -1,0 +1,118 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2011-2014, CloudBees, Inc., Vincent Latombe
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.cloudbees.literate.jenkins.promotions.conditions;
+
+import hudson.Extension;
+import hudson.model.AbstractBuild;
+import hudson.model.Result;
+import hudson.model.TaskListener;
+import hudson.model.listeners.RunListener;
+import org.cloudbees.literate.jenkins.LiterateBranchBuild;
+import org.cloudbees.literate.jenkins.LiterateBranchProject;
+import org.cloudbees.literate.jenkins.promotions.*;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.IOException;
+
+/**
+ * {@link PromotionCondition} that promotes a build as soon as it's done.
+ *
+ * @author Kohsuke Kawaguchi
+ */
+public class SelfPromotionCondition extends PromotionCondition {
+  private final boolean evenIfUnstable;
+
+  @DataBoundConstructor
+  public SelfPromotionCondition(boolean evenIfUnstable) {
+    this.evenIfUnstable = evenIfUnstable;
+  }
+
+  public boolean isEvenIfUnstable() {
+    return evenIfUnstable;
+  }
+
+  @Override
+  public PromotionBadge isMet(PromotionProject promotionProject, LiterateBranchBuild build) {
+    if (!build.isBuilding()) {
+      Result r = build.getResult();
+      if ((r == Result.SUCCESS) || (evenIfUnstable && r == Result.UNSTABLE)) {
+        return new SelfPromotionBadge();
+      }
+    }
+    return null;
+  }
+
+  /**
+   * {@link RunListener} to pick up completions of a build.
+   * <p/>
+   * <p/>
+   * This is a single instance that receives all the events everywhere in the system.
+   *
+   * @author Kohsuke Kawaguchi
+   */
+  @Extension
+  public static final class RunListenerImpl extends RunListener<AbstractBuild<?, ?>> {
+    public RunListenerImpl() {
+      super((Class) AbstractBuild.class);
+    }
+
+    @Override
+    public void onCompleted(AbstractBuild<?, ?> build, TaskListener listener) {
+      if (build instanceof LiterateBranchBuild) {
+        LiterateBranchBuild lbb = (LiterateBranchBuild) build;
+        LiterateBranchProject lbp = lbb.getProject();
+        PromotionBranchProperty property = lbp.getBranch().getProperty(PromotionBranchProperty.class);
+        if (property != null) {
+          for (PromotionConfiguration c : property.getConfigurations()) {
+            for (PromotionCondition p : c.getConditions()) {
+              if (p instanceof SelfPromotionCondition) {
+                PromotionJobProperty pjp = lbp.getProperty(PromotionJobProperty.class);
+                if (pjp == null) {
+                  throw new IllegalStateException("This project doesn't have any promotion criteria set");
+                }
+                PromotionProject item = pjp.getItem(c.getName());
+                if (item == null) {
+                  throw new IllegalStateException("This project doesn't have the promotion criterion called " + c.getName());
+                }
+                try {
+                  item.considerPromotion(lbb);
+                } catch (IOException e) {
+                  e.printStackTrace(listener.error("Failed to promote a build"));
+                }
+                break;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  @Extension
+  public static final class DescriptorImpl extends PromotionConditionDescriptor {
+    public String getDisplayName() {
+      return Messages.SelfPromotionCondition_DisplayName();
+    }
+  }
+}

--- a/src/main/resources/org/cloudbees/literate/jenkins/promotions/SelfPromotionBadge/index.jelly
+++ b/src/main/resources/org/cloudbees/literate/jenkins/promotions/SelfPromotionBadge/index.jelly
@@ -1,0 +1,26 @@
+<!--
+ ~ The MIT License
+ ~
+ ~ Copyright (c) 2014, Vincent Latombe
+ ~
+ ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+ ~ of this software and associated documentation files (the "Software"), to deal
+ ~ in the Software without restriction, including without limitation the rights
+ ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ ~ copies of the Software, and to permit persons to whom the Software is
+ ~ furnished to do so, subject to the following conditions:
+ ~
+ ~ The above copyright notice and this permission notice shall be included in
+ ~ all copies or substantial portions of the Software.
+ ~
+ ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ ~ THE SOFTWARE.
+-->
+<div>
+    ${%Automatically promoted immediately after the build}
+</div>

--- a/src/main/resources/org/cloudbees/literate/jenkins/promotions/conditions/Messages.properties
+++ b/src/main/resources/org/cloudbees/literate/jenkins/promotions/conditions/Messages.properties
@@ -1,7 +1,7 @@
 #
 # The MIT License
 #
-# Copyright (c) 2014, CloudBees, Inc.
+# Copyright (c) 2014, CloudBees, Inc., Vincent Latombe
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,3 +23,5 @@
 #
 
 ManualCondition.displayName=Manual
+SelfPromotionCondition.DisplayName=Promote immediately once the build is complete
+ParameterizedSelfPromotionCondition.DisplayName=Promote immediately once the build is complete based on build parameters

--- a/src/main/resources/org/cloudbees/literate/jenkins/promotions/conditions/SelfPromotionCondition/config.jelly
+++ b/src/main/resources/org/cloudbees/literate/jenkins/promotions/conditions/SelfPromotionCondition/config.jelly
@@ -1,0 +1,29 @@
+<!--
+ ~ The MIT License
+ ~
+ ~ Copyright (c) 2014, Vincent Latombe
+ ~
+ ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+ ~ of this software and associated documentation files (the "Software"), to deal
+ ~ in the Software without restriction, including without limitation the rights
+ ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ ~ copies of the Software, and to permit persons to whom the Software is
+ ~ furnished to do so, subject to the following conditions:
+ ~
+ ~ The above copyright notice and this permission notice shall be included in
+ ~ all copies or substantial portions of the Software.
+ ~
+ ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ ~ THE SOFTWARE.
+-->
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry>
+        <f:checkbox name="promotion.self.evenIfUnstable" checked="${instance.evenIfUnstable}"/>
+        <label class="attach-previous">${%Trigger even if the build is unstable}</label>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/org/cloudbees/literate/jenkins/promotions/conditions/SelfPromotionCondition/help.html
+++ b/src/main/resources/org/cloudbees/literate/jenkins/promotions/conditions/SelfPromotionCondition/help.html
@@ -1,0 +1,11 @@
+<div>
+    Promote a build as soon as a build is completed. This mechanism is convenient for associating
+    small additional tasks at the end of the build. Compared to making it a part of the build,
+    the difference is that this makes
+    the additional step retryable, and a failure will not render the whole build as a failure.
+
+    <p>
+        This criteria can be also handy for consistency; say you have a lot of components built uniformly,
+        and many of them have real test jobs hooked up as the downstream promotion criteria, but some of them
+        might not have any. In such a case, you'll want to immediately promote it.
+</div>

--- a/src/main/resources/org/cloudbees/literate/jenkins/promotions/conditions/SelfPromotionCondition/index.jelly
+++ b/src/main/resources/org/cloudbees/literate/jenkins/promotions/conditions/SelfPromotionCondition/index.jelly
@@ -1,0 +1,26 @@
+<!--
+ ~ The MIT License
+ ~
+ ~ Copyright (c) 2014, Vincent Latombe
+ ~
+ ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+ ~ of this software and associated documentation files (the "Software"), to deal
+ ~ in the Software without restriction, including without limitation the rights
+ ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ ~ copies of the Software, and to permit persons to whom the Software is
+ ~ furnished to do so, subject to the following conditions:
+ ~
+ ~ The above copyright notice and this permission notice shall be included in
+ ~ all copies or substantial portions of the Software.
+ ~
+ ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ ~ THE SOFTWARE.
+-->
+<div>
+    ${%Build failed - cannot be automatically promoted}
+</div>


### PR DESCRIPTION
This provides self promotions, which can be useful to chain build with a promotion operation that is not environment-specific.
