### PR TITLE
[JENKINS-30744] Updated to use Branch.encodedName

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.580.3</version> <!-- to match branch-api -->
+    <version>1.609.1</version> <!-- to match branch-api -->
   </parent>
 
   <artifactId>literate</artifactId>
@@ -118,7 +118,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>branch-api</artifactId>
-      <version>0.2-beta-4</version>
+      <version>0.2-beta-7-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/cloudbees/literate/jenkins/LiterateBranchProject.java
+++ b/src/main/java/org/cloudbees/literate/jenkins/LiterateBranchProject.java
@@ -129,7 +129,7 @@ public class LiterateBranchProject extends Project<LiterateBranchProject, Litera
      * @param branch the branch.
      */
     public LiterateBranchProject(@NonNull LiterateMultibranchProject parent, @NonNull Branch branch) {
-        super(parent, branch.getName());
+        super(parent, branch.getEncodedName());
         this.branch = branch;
     }
 
@@ -202,15 +202,6 @@ public class LiterateBranchProject extends Project<LiterateBranchProject, Litera
         }
     }
 
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    @NonNull
-    public synchronized String getName() {
-        return branch.getName();
-    }
 
     /**
      * {@inheritDoc}


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/branch-api-plugin/pull/18. Interactively tested using [this repo](https://github.com/jglick/literate-demo).

Did not touch encoding of environments, which seems to be an independent system.

@reviewbybees esp. @stephenc